### PR TITLE
add flow to dl youtube videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tools
 lib
 activate_venv
 runtests.sh
+
+# PyCharm
+.idea

--- a/simulacra/youtube_dl/cli.py
+++ b/simulacra/youtube_dl/cli.py
@@ -1,0 +1,39 @@
+from argparse import ArgumentParser
+
+from flows.simulacra.youtube_dl.post import download_videos
+from jobrunner.cli.parse import parse_arguments
+from jobrunner.plugins import register_job
+
+
+def parse_youtube_dl_arguments(args=None):
+    """
+    Parse the commandline options for posting a job that
+    downloads videos from YouTube to the local disk of the
+    conductor running the flow
+    :param list args: Args to pass to the arg parser.
+    Will use argv if none specified.
+    :return obj args: parsed arguments
+    """
+    parser = ArgumentParser(
+        prog="jobrunner post youtube_dl",
+        description='Post a job that downloads videos from YouTube'
+    )
+    parser.add_argument(
+        'channels_file',
+        help="Path to a file containing a list of channels to "
+             "download the videos of"
+    )
+    return parse_arguments(parser, args=args)
+
+
+@register_job()
+def youtube_dl_latest(args=None):
+    """
+    Post a job that downloads the latest youtube videos of a list
+    of channels provided as an argument.
+    :param list args: Args to pass to the arg parser.
+    Will use argv if none specified.
+    :return None:
+    """
+    args = parse_youtube_dl_arguments(args=args)
+    download_videos(channels_file=args.channels_file)

--- a/simulacra/youtube_dl/factory.py
+++ b/simulacra/youtube_dl/factory.py
@@ -1,0 +1,20 @@
+from logging import getLogger
+from taskflow.patterns import graph_flow as gf
+from taskflow.retry import Times
+
+from flows.simulacra.youtube_dl.tasks import DownloadVideos
+
+log = getLogger(__name__)
+
+
+def youtube_dl_flow_factory(channels):
+    f = gf.Flow("youtube_dl_flow", retry=Times(3))
+    for channel in channels:
+        log.info("Adding dl task for {}".format(channel))
+        f.add(
+            DownloadVideos(
+                "yt_dl_{}".format(channel),
+                inject={'channel': channel}
+            )
+        )
+    return f

--- a/simulacra/youtube_dl/post.py
+++ b/simulacra/youtube_dl/post.py
@@ -1,0 +1,18 @@
+from flows.simulacra.youtube_dl.factory import youtube_dl_flow_factory
+from jobrunner.post_job import post_job
+
+
+def download_videos(channels_file):
+    """
+    Post a job to downloads the latest youtube videos of specified channels
+    :param str channels_file: Path to a file containing a list of channels
+    :return None:
+    """
+    with open(channels_file) as f:
+        channels = [l.strip() for l in f.readlines()]
+
+    post_job(
+        youtube_dl_flow_factory,
+        factory_args=[channels],
+        store={'channels': channels}
+    )

--- a/simulacra/youtube_dl/tasks.py
+++ b/simulacra/youtube_dl/tasks.py
@@ -1,0 +1,19 @@
+from logging import getLogger
+
+from subprocess import check_call
+from taskflow.task import Task
+
+log = getLogger(__name__)
+
+
+class DownloadVideos(Task):
+    def execute(self, channel):
+        log.info(
+            "Downloading latest videos from "
+            "configured channel {}".format(channel)
+        )
+        check_call(
+            "youtube-dl --verbose -citw ytuser:{} "
+            "--max-downloads 5".format(channel),
+            shell=True
+        )


### PR DESCRIPTION
add flow to dl youtube videos based on a specified list of channels on any eligible conductor

```
~/code/projects/simulacra$ ./bin/jobrunner post --help

usage: jobrunner post [-h] [--verbose] {job_name}

Post a job to the job board

available jobs:
  youtube_dl_latest
  simple_http_webserver
                        The job to post

optional arguments:
  -h, --help            show this help message and exit
  --verbose, -v

~/code/projects/simulacra$ ./bin/jobrunner post youtube_dl_latest --help
usage: jobrunner post youtube_dl [-h] [--verbose] channels_file

Post a job that downloads videos from YouTube

positional arguments:
  channels_file  Path to a file containing a list of channels to download the
                 videos of

optional arguments:
  -h, --help     show this help message and exit
  --verbose, -v

```