### PR TITLE
add htpc compute type

### DIFF
--- a/raptiformica.json
+++ b/raptiformica.json
@@ -11,6 +11,16 @@
         "detect_stale_instance": "cd vagrantfiles/workstation && vagrant status | grep running",
         "clean_up_instance_command": "cd vagrantfiles/workstation && vagrant destroy -f",
         "package": "cd vagrantfiles/workstation && sh package.sh"
+      },
+      "htpc": {
+        "available": "vagrant -v",
+        "source": "https://github.com/vdloo/simulacra",
+        "start_instance": "cd vagrantfiles/workstation && vagrant up",
+        "get_hostname": "cd vagrantfiles/workstation && nohup vagrant ssh -c 'ip addr show' 2>&1 | grep 'inet ' | tail -n 1 | awk '{print$2}' | cut -d '/' -f1",
+        "get_port": "echo 22",
+        "detect_stale_instance": "cd vagrantfiles/workstation && vagrant status | grep running",
+        "clean_up_instance_command": "cd vagrantfiles/workstation && vagrant destroy -f",
+        "package": "cd vagrantfiles/workstation && sh package.sh"
       }
     }
   },


### PR DESCRIPTION
so I can run:
```
$ raptiformica install vdloo/simulacra
$ raptiformica spawn --compute-type vagrant --server-type htpc
```

to spawn a Vagrant with a gui that will run the [htpc puppet manifest](https://github.com/vdloo/simulacra/blob/master/puppetfiles/provisioning/roles/htpc/manifests/init.pp) to set up a htpc environment (dwm + kodi)