### PR TITLE
fix error while evaluating function in autologin

### DIFF
--- a/puppetfiles/provisioning/modules/autologin/templates/override.conf.erb
+++ b/puppetfiles/provisioning/modules/autologin/templates/override.conf.erb
@@ -2,8 +2,8 @@
 ExecStart=
 <% case @operatingsystem
 when "Ubuntu" %>
-ExecStart=-/sbin/agetty --autologin <%= scope().call_function('hiera',['nonroot_username']) %> --noclear %I $TERM
+ExecStart=-/sbin/agetty --autologin <%= @nonroot_username %> --noclear %I $TERM
 <% else %>
-ExecStart=-/usr/bin/agetty --autologin <%= scope().call_function('hiera',['nonroot_username']) %> --noclear %I $TERM
+ExecStart=-/usr/bin/agetty --autologin <%= @nonroot_username %> --noclear %I $TERM
 <% end %>
 Type=simple


### PR DESCRIPTION
fixes:
```
Debug: Lookup of 'nonroot_username'
  Searching for "nonroot_username"
    Global Data Provider (hiera configuration version 3)
      Using configuration "/usr/etc/puppetfiles/puppetfiles/provisioning/hiera/hiera.yaml"
      Hierarchy entry "yaml"
        Path "/usr/etc/hieradata/common.yaml"
          Original path: "common"
          Path not found
Traceback (most recent call last):
  File "/usr/share/raptiformica/bin/raptiformica_spawn.py", line 5, in <module>
    spawn()
  File "/usr/share/raptiformica/raptiformica/cli.py", line 165, in spawn
    only_check_available=args.check_available
  File "/usr/share/raptiformica/raptiformica/actions/spawn.py", line 130, in spawn_machine
    uuid=uuid
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 128, in slave_machine
    provision_machine(host, port=port, server_type=server_type)
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 74, in provision_machine
    callback=bootstrap_provisioning
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 56, in ensure_source_on_machine
    callback(name, config)
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 70, in bootstrap_provisioning
    run_resource_command(config['bootstrap'], name, host=host, port=port)
  File "/usr/share/raptiformica/raptiformica/utils.py", line 150, in retry_wrapper
    return func(*args, **kwargs)
  File "/usr/share/raptiformica/raptiformica/shell/config.py", line 38, in run_resource_command
    shell=True
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 345, in run_command_print_ready
    buffered=buffered, shell=shell, timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 257, in run_command
    timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 226, in run_command_remotely
    timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 184, in run_command_locally
    failure_callback(process_output)
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 278, in print_ready_callback
    callback(make_process_output_print_ready(process_output))
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 26, in raise_failure
    raise RuntimeError("{}\n{}".format(message, standard_error))
RuntimeError: Resource command exited nonzero, that might not be a problem. If something serious went wrong we'll try again next run.
Warning: Permanently added '172.28.128.3' (ECDSA) to the list of known hosts.
Warning: The function 'hiera' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/5.5/reference/deprecated_language.html
   (file & line not available)
Warning: /usr/etc/puppetfiles/puppetfiles/provisioning/hiera/hiera.yaml: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5
   (file: /usr/etc/puppetfiles/puppetfiles/provisioning/hiera/hiera.yaml)
Error: Evaluation Error: Error while evaluating a Function Call, Failed to parse template autologin/override.conf.erb:
  Filepath: /usr/lib/ruby/vendor_ruby/2.5.0/puppet/pops/lookup.rb
  Line: 87
  Detail: Function lookup() did not find a value for the name 'nonroot_username'
 (file: /usr/etc/puppetfiles/puppetfiles/provisioning/modules/autologin/manifests/init.pp, line: 8, column: 16) on node archlinux
```