### PR TITLE
do not run configmgmt during assimilation

### DIFF
--- a/raptiformica.json
+++ b/raptiformica.json
@@ -25,39 +25,13 @@
     }
   },
   "server": {
-    "headless": {
-      "simulacra": {
-        "source": "https://github.com/vdloo/simulacra",
-        "bootstrap": "/usr/bin/env screen -d -m bash deploy.sh"
-      },
-      "puppetfiles": {
-        "bootstrap": "cd puppetfiles/provisioning && ./papply.sh manifests/headless.pp",
-        "source": "https://github.com/vdloo/simulacra"
-      }
-    },
     "workstation": {
-      "simulacra": {
-        "source": "https://github.com/vdloo/simulacra",
-        "bootstrap": "/usr/bin/env screen -d -m bash deploy.sh"
-      },
-      "puppetfiles": {
-        "bootstrap": "cd puppetfiles/provisioning && ./papply.sh manifests/workstation.pp",
-        "source": "https://github.com/vdloo/simulacra"
-      },
       "raptiformica_default_provisioner": {
         "source": "file:///usr/etc/raptiformica",
         "bootstrap": "cd $HOME; export PYTHONPATH=/usr/etc/raptiformica_default_provisioner; /usr/etc/raptiformica_default_provisioner/modules/server/deploy.py"
       }
     },
     "htpc": {
-      "simulacra": {
-        "source": "https://github.com/vdloo/simulacra",
-        "bootstrap": "/usr/bin/env screen -d -m bash deploy.sh"
-      },
-      "puppetfiles": {
-        "bootstrap": "cd puppetfiles/provisioning && ./papply.sh manifests/htpc.pp",
-        "source": "https://github.com/vdloo/simulacra"
-      },
       "raptiformica_default_provisioner": {
         "source": "file:///usr/etc/raptiformica",
         "bootstrap": "cd $HOME; export PYTHONPATH=/usr/etc/raptiformica_default_provisioner; /usr/etc/raptiformica_default_provisioner/modules/server/deploy.py"


### PR DESCRIPTION
decoupling the configuration management from the overlay network bootstrapping process. if the configuration management fails it should not prevent the network from being established. also, doing the configuration management at that stage takes a long time and makes debugging difficult.