### PR TITLE
pin sudo puppet module to 4.2.0

### DIFF
--- a/vagrantfiles/workstation/deps/archlinux_deps.sh
+++ b/vagrantfiles/workstation/deps/archlinux_deps.sh
@@ -8,7 +8,7 @@ pacman -Sy --noconfirm
 pacman -S ruby python3 rsync git icu puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen xf86-video-vesa --noconfirm --needed
 puppet module install puppetlabs-vcsrepo
 puppet module install maestrodev-wget
-puppet module install saz-sudo
+puppet module install saz-sudo --version=4.2.0
 
 # Make sure the kernel is not upgraded on 'pacman -Syu' because otherwise we'd need to reboot
 # yet again before docker will work inside the virtualized guest due to the right veth kernel module 


### PR DESCRIPTION
later version broke something
```
Debug: importing '/etc/puppet/modules/sudo/manifests/init.pp' in environment production
Running configuration management on fc00:d4e0:31b6:e19:a983:e335:4569:2b26 failed, error was: (b'', b"Warning: Permanently added 'fc00:d4e0:31b6:e19:a983:e335:4569:2b26' (ECDSA) to the list of known hosts.\r\n\x1b[1;31mError: Syntax error at 'Boolean'; expected ')' at /etc/puppet/modules/sudo/manifests/init.pp:97 on node retropie\x1b[0m\n\x1b[1;31mError: Syntax error at 'Boolean'; expected ')' at /etc/puppet/modules/sudo/manifests/init.pp:97 on node retropie\x1b[0m\n")
Running configuration management on fc03:cced:19b5:7c78:b7e5:520d:b7e3:1357
```