### PR TITLE
puppet apply is puppet3 compatible

### DIFF
--- a/puppetfiles/provisioning/papply.sh
+++ b/puppetfiles/provisioning/papply.sh
@@ -6,5 +6,9 @@ else
 	hieraconfig="$dirname/hiera/hiera.yaml"
 	base=$(puppet master --configprint modulepath);
 	modulepath="$base:$dirname/modules:$dirname/roles:$dirname/operating_systems" 
-	puppet apply --verbose --debug --modulepath="$modulepath" --hiera_config=$hieraconfig "$@"; 
+        if puppet --version | grep -q "^3\."; then
+	    puppet apply --verbose --debug --modulepath="$modulepath" --hiera_config=$hieraconfig "$@"; 
+        else
+	    puppet apply --no-stringify_facts --trusted_node_data --verbose --debug --modulepath="$modulepath" --hiera_config=$hieraconfig "$@"; 
+        fi
 fi


### PR DESCRIPTION
fixes:
```
Error: ::facts is not a hash or array when accessing it with simulacra at /root/.raptiformica.d/modules/simulacra/puppetfiles/provisioning/modules/redis/manifests/init.pp:2 on node retropie
Error: ::facts is not a hash or array when accessing it with simulacra at /root/.raptiformica.d/modules/simulacra/puppetfiles/provisioning/modules/redis/manifests/init.pp:2 on node retropie
```
on puppet 3 hosts