### PR TITLE
use redis-server on debian and ubuntu

### DIFF
--- a/puppetfiles/provisioning/modules/redis/manifests/init.pp
+++ b/puppetfiles/provisioning/modules/redis/manifests/init.pp
@@ -13,17 +13,16 @@ class redis {
     if $redis_enabled {
         require install_redis
     }
-
-    service { 'redis':
+    $redis = $operatingsystem ? {
+        /^(Debian|Ubuntu)$/ => 'redis-server',
+        default => 'redis',
+    }
+    service { "$redis":
         ensure => $redis_enabled ? {true => 'running', default => 'stopped'}
     }
 }
 
 class install_redis {
-    $redis = $operatingsystem ? {
-        /^(Debian|Ubuntu)$/ => 'redis-server',
-        default => 'redis',
-    }
     if $facts['simulacra'] {
         $simulacra = $facts['simulacra']
     } else {
@@ -41,6 +40,10 @@ class install_redis {
     file { '/etc/redis/redis.conf':
         ensure => file,
         content => template('redis/redis.conf.erb')
+    }
+    $redis = $operatingsystem ? {
+        /^(Debian|Ubuntu)$/ => 'redis-server',
+        default => 'redis',
     }
     package { "$redis":
         ensure => 'installed',


### PR DESCRIPTION
instead of just 'redis'. it is just redis from Debian 9 on though, but my raspberry pi is still running jessie.