### PR TITLE
force simulacra vcs repo

### DIFF
--- a/puppetfiles/provisioning/roles/common/manifests/init.pp
+++ b/puppetfiles/provisioning/roles/common/manifests/init.pp
@@ -90,6 +90,7 @@ class update_puppetfiles {
     provider => git,
     source => 'https://github.com/vdloo/simulacra',
     revision => 'master',
+    force => true
   }
 }
 


### PR DESCRIPTION
for:
```
Notice: /Stage[main]/Update_puppetfiles/Vcsrepo[/root/.raptiformica.d/modules/simulacra]/ensure: Creating repository from latest
Error: Path /root/.raptiformica.d/modules/simulacra exists and is not the desired repository.
Error: /Stage[main]/Update_puppetfiles/Vcsrepo[/root/.raptiformica.d/modules/simulacra]/ensure: change from absent to latest failed: Path /root/.raptiformica.d/modules/simulacra exists and is not the desired repository.
```