### PR TITLE
increase jobrunner timeout

### DIFF
--- a/puppetfiles/provisioning/modules/jobrunner/manifests/init.pp
+++ b/puppetfiles/provisioning/modules/jobrunner/manifests/init.pp
@@ -1,6 +1,7 @@
 class jobrunner {
     exec { 'ensure jobrunner is running':
         command => 'ps aux | grep -q "/root/.raptiformica.d/modules/simulacra/bin/[j]obrunner_run" || sh /root/.raptiformica.d/modules/simulacra/deploy.sh',
-        provider => 'shell'
+        provider => 'shell',
+        timeout => 1800
     }
 }


### PR DESCRIPTION
pip install in the ansible playbook can take a while on machines with very bad iops