### PR TITLE
Revert "do not use macvtap but internal network instead"

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,16 +7,16 @@ resource "libvirt_volume" "grid-qcow2" {
   pool = "default"
   format = "qcow2"
   source = "/home/vdloo/images/grid0.qcow2"
-  count = 20
+  count = 5
 }
 
 resource "libvirt_domain" "grid" {
   name = "grid${count.index}"
-  memory = "1024"
-  vcpu = 1
+  memory = "10240"
+  vcpu = 2
 
   network_interface {
-    network_name = "default"
+    macvtap = "enp0s31f6"
   }
   boot_device {
     dev = ["hd"]
@@ -28,6 +28,6 @@ resource "libvirt_domain" "grid" {
     type = "vnc"
     listen_type = "address"
   }
-  count = 20
+  count = 5
 }
 


### PR DESCRIPTION
Reverts vdloo/simulacra#91

using the default networking is buggy:
```
libvirt_domain.grid.2: Still creating... (10s elapsed)
libvirt_domain.grid.1: Still creating... (10s elapsed)
libvirt_domain.grid.3: Still creating... (10s elapsed)
libvirt_domain.grid.2: Still creating... (20s elapsed)
libvirt_domain.grid.1: Still creating... (20s elapsed)
libvirt_domain.grid.3: Still creating... (20s elapsed)
libvirt_domain.grid.2: Still creating... (30s elapsed)
libvirt_domain.grid.1: Still creating... (30s elapsed)
libvirt_domain.grid.3: Still creating... (30s elapsed)
libvirt_domain.grid[3]: Creation complete after 33s (ID: a87eb072-f715-49f5-b45b-e39d86b498c7)
libvirt_domain.grid[1]: Creation complete after 33s (ID: 4c2ba699-a744-4f43-a38e-b611806cd5e9)
libvirt_domain.grid[2]: Creation complete after 33s (ID: 811c2fab-b1d6-42dc-8d6e-d2fef9de58ed)

Error: Error applying plan:

1 error(s) occurred:

* libvirt_domain.grid[0]: 1 error(s) occurred:

* libvirt_domain.grid.0: Error creating libvirt domain: virError(Code=43, Domain=19, Message='Network not found: no network with matching name 'default'')

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```